### PR TITLE
chore: fix readme and add license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright 2023 thenorthbay
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/readme.md
+++ b/readme.md
@@ -9,19 +9,18 @@ This is early work, so please treat it appropriately.
 
 Example:
 
-```
+```javascript
 import { Database } from "doculite"
 
 // Creates sqlite.db file in the cwd
 const db = new Database();
-
 ```
 
 ## 2. Create Collections and Set Documents
 
 Collections are created on first insertion of a document. They are represented by a SQLite Table.
 
-```
+```javascript
 // create ref to the doc. Doc ID optional.
 
 const usersRef = db.collection("users").doc("123");
@@ -31,24 +30,22 @@ const refWithoutId = db.collection("users").doc();
 
 await usersRef.set({ username: "John Doe", createdAt: "123", updatedAt: "123" });
 await refWithoutId.set({ username: "Jane Doe" });
-
 ```
 
 ## 3. Get a particular document
 
-```
+```javascript
 // define ref
 const usersRef = db.collection("users").doc("123");
 // get
 const user = await usersRef.get();
 // print
 console.log(user); // prints { username: "John Doe" };
-
 ```
 
 ## 4. Update Documents in Collections
 
-```
+```javascript
 // ref
 const usersRef = db.collection("users").doc("123");
 
@@ -63,12 +60,11 @@ await ref.set({ username: "DERP Doe", updatedAt: "345" }, { merge: true });
 
 await ref.set({ username: "DERP Doe", updatedAt: "345" }, { merge: false });
 // document in DB is now { username: "DERP Doe", updatedAt: "345" }
-
 ```
 
 ## 5. Delete Documents in Collection
 
-```
+```javascript
 const db = new Database();
 
 const ref = db.collection("users").doc("deletable");
@@ -80,13 +76,11 @@ await ref.delete();
 const doc = await ref.get();
 
 console.log(doc) // prints null
-
 ```
 
 ## 6. Listen to real-time updates of documents.
 
-```
-
+```javascript
 // ref to doc
 const ref = db.collection("users").doc("123");
 
@@ -100,13 +94,11 @@ await ref.set({ username: "SHEESH Doe", updatedAt: 2 });
 
 // unsub
 unsub();
-
 ```
 
 ## 7. Query Documents in a collection by equality comparison
 
-```
-
+```javascript
 const usersRef = db.collection("users");
 
 await usersRef.doc().set({ username: "Doculite", updatedAt: 234 });
@@ -118,7 +110,6 @@ const docs = await query.get();
 const user = docs[0]
 
 console.log(user.username) // prints `Doculite`
-
 ```
 
 # Potential roadmap:
@@ -131,7 +122,3 @@ console.log(user.username) // prints `Doculite`
 6. Queries with other comparison operators (<, >, >=, <=, contains, etc.)
 7. Queries for multiple variables (without indexes, probably)
 8. Queries with Full Text Search (without indexes, probably)
-
-```
-
-```


### PR DESCRIPTION
Adding language indicators to code blocks in Markdown helps readability.  
Also added a license file — package.json says MIT, so that's what I went with. if that's not what you want to use, feel free to ask for changes here.  